### PR TITLE
Fix custom input view container height on smaller keyboards

### DIFF
--- a/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
@@ -128,7 +128,10 @@ public class ExpandableChatInputBarPresenter: NSObject, ChatInputBarPresenter {
 
     private var lastKnownKeyboardHeight: CGFloat?
     private var keyboardHeight: CGFloat {
-        return self.lastKnownKeyboardHeight ?? self.defaultKeyboardHeight
+        guard let lastKnownKeyboardHeight = self.lastKnownKeyboardHeight else {
+            return self.defaultKeyboardHeight
+        }
+        return max(lastKnownKeyboardHeight, self.defaultKeyboardHeight)
     }
     private var allowListenToChangeFrameEvents = true
 


### PR DESCRIPTION
## Summary
- Ensure `keyboardHeight` in `ExpandableChatInputBarPresenter` never drops below `defaultKeyboardHeight`
- Fixes an issue where switching between keyboard and custom input views (e.g., audio recorder) caused the content container to be too small on certain devices/OS versions

## Problem
When switching from keyboard to a custom input view, `lastKnownKeyboardHeight` could be recalculated with a smaller value. This happened because the chat input bar shrinks (text view hidden) during the transition while `keyboardDidChangeFrame` fires with the bar's reduced height, producing an incorrect keyboard height value.

On affected devices (e.g., iPhone 17 Pro / iOS 26), the content container ended up being ~177pt instead of ~335pt, pushing the custom input view's action buttons off-screen and making them untappable.

## Fix
One-line change: use `max(lastKnownKeyboardHeight, defaultKeyboardHeight)` instead of just `lastKnownKeyboardHeight`. This guarantees the container always has at least the default keyboard height worth of space for custom input views.

## Test plan
- [ ] Open a chat conversation with keyboard visible
- [ ] Switch to a custom input view (e.g., audio recorder via mic button)
- [ ] Switch back to keyboard
- [ ] Switch to audio recorder again
- [ ] Verify all elements (record button, timer, waveform, send/reload buttons) are visible and tappable
- [ ] Test on both iPhone 16 (iOS 18) and iPhone 17 Pro (iOS 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)